### PR TITLE
catch exception when parsing invalid pbf - fixes #817

### DIFF
--- a/tile-join.cpp
+++ b/tile-join.cpp
@@ -75,8 +75,13 @@ void handle(std::string message, int z, unsigned x, unsigned y, std::map<std::st
 	int features_added = 0;
 	bool was_compressed;
 
-	if (!tile.decode(message, was_compressed)) {
-		fprintf(stderr, "Couldn't decompress tile %d/%u/%u\n", z, x, y);
+	try {
+		if (!tile.decode(message, was_compressed)) {
+			fprintf(stderr, "Couldn't decompress tile %d/%u/%u\n", z, x, y);
+			exit(EXIT_FAILURE);
+		}
+	} catch (std::exception const &e) {
+		fprintf(stderr, "PBF decoding error in tile %d/%u/%u\n", z, x, y);
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
https://acmeaom.slack.com/archives/G01N5K5MEM8/p1631835896026400

catch exception when decoding so that error message is printed